### PR TITLE
Fix/async read

### DIFF
--- a/cpp/pixels-core/include/reader/PixelsRecordReaderImpl.h
+++ b/cpp/pixels-core/include/reader/PixelsRecordReaderImpl.h
@@ -53,6 +53,9 @@ public:
 	bool isEndOfFile() override;
     ~PixelsRecordReaderImpl();
 	void close() override;
+    
+    uint32_t has_async_task_{0};
+
 private:
     std::vector<int64_t> bufferIds;
     void prepareRead();

--- a/cpp/pixels-core/include/reader/PixelsRecordReaderImpl.h
+++ b/cpp/pixels-core/include/reader/PixelsRecordReaderImpl.h
@@ -54,7 +54,7 @@ public:
     ~PixelsRecordReaderImpl();
 	void close() override;
     
-    uint32_t has_async_task_{0};
+    uint32_t has_async_task_num_{0};
 
 private:
     std::vector<int64_t> bufferIds;

--- a/cpp/pixels-core/lib/reader/PixelsRecordReaderImpl.cpp
+++ b/cpp/pixels-core/lib/reader/PixelsRecordReaderImpl.cpp
@@ -42,7 +42,6 @@ PixelsRecordReaderImpl::PixelsRecordReaderImpl(std::shared_ptr<PhysicalReader> r
     includedColumnNum = 0;
 	endOfFile = false;
     resultRowBatch = nullptr;
-    ::DirectUringRandomAccessFile::Initialize();
     checkBeforeRead();
 }
 
@@ -182,6 +181,11 @@ std::shared_ptr<VectorizedRowBatch> PixelsRecordReaderImpl::readBatch(bool reuse
     }
 
     std::vector<int> filterColumnIndex;
+
+    if(has_async_task_ > 0) {
+        asyncReadComplete(has_async_task_);
+    }
+
     if(filter != nullptr) {
         for (auto &filterCol : filter->filters) {
             if(filterMask->isNone()) {
@@ -323,10 +327,12 @@ void PixelsRecordReaderImpl::prepareRead() {
 }
 
 void PixelsRecordReaderImpl::asyncReadComplete(int requestSize) {
-    if(ConfigFactory::Instance().boolCheckProperty("localfs.enable.async.io")) {
+    // std::cerr << "DEBUG2: Wait Async Size: " << requestSize << std::endl;
+    if(ConfigFactory::Instance().boolCheckProperty("localfs.enable.async.io") && has_async_task_ >= requestSize) {
         if(ConfigFactory::Instance().getProperty("localfs.async.lib") == "iouring") {
             auto localReader = std::static_pointer_cast<PhysicalLocalReader>(physicalReader);
             localReader->readAsyncComplete(requestSize);
+            has_async_task_ -= requestSize;
         } else if(ConfigFactory::Instance().getProperty("localfs.async.lib") == "aio") {
             throw InvalidArgumentException("PhysicalLocalReader::readAsync: We don't support aio for our async read yet.");
         }
@@ -390,6 +396,10 @@ bool PixelsRecordReaderImpl::read() {
 		}
 
 		auto byteBuffers = scheduler->executeBatch(physicalReader, requestBatch, originalByteBuffers, queryId);
+
+        if(ConfigFactory::Instance().boolCheckProperty("localfs.enable.async.io") && originalByteBuffers.size() > 0) {
+            has_async_task_ = diskChunks.size();
+	    }
 
         for(int index = 0; index < diskChunks.size(); index++) {
             ChunkId chunk = diskChunks.at(index);


### PR DESCRIPTION
## BUG
多行数据只能显示前几行
![711ff706f8fe4cf179ef27cc26f7991e_](https://github.com/user-attachments/assets/b8eb0035-7bc6-49f3-a023-f42001d20880)

## 产生原因

开启async io后，同一文件多个row group，只有第一个rg会等待cqe。如下图所示，
![image](https://github.com/user-attachments/assets/341a9264-60ed-48e6-a33e-223c32f68905)


## 目前的解决方案

保证在每个row group第一个batch被阅读前，等待异步读完成。


## 复现方法

测试数据
```plain text
1|2|
2|4|
3|6|
4|8|
5|10|
6|12|
7|14|
8|16|
9|18|
10|20|
11|22|
12|24|
13|26|
14|28|
15|30|
16|32|
17|34|
18|36|
19|38|
20|40|
21|42|
22|44|
23|46|
24|48|
25|50|
26|52|
27|54|
28|56|
29|58|
30|60|
31|62|
32|64|
33|66|
34|68|
35|70|
36|72|
37|74|
38|76|
39|78|
40|80|
```

Pixels-CLI:
```bash
LOAD -e 0 -o input -t output -s struct<a:int,b:int> -n 100 -r \|
```